### PR TITLE
Allow empty objects

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -53,7 +53,7 @@ DECIMAL : "0".."9"
 EXP_MARK : ("e" | "E") ("+" | "-")?
 
 tuple : "[" (new_line_or_comment? expression (new_line_or_comment? "," new_line_or_comment? expression)* new_line_or_comment? ","?)? new_line_or_comment? "]"
-object : "{" (new_line_or_comment? object_elem (new_line_and_or_comma object_elem )* new_line_and_or_comma?)? "}"
+object : "{" new_line_or_comment? (object_elem (new_line_and_or_comma object_elem )* new_line_and_or_comma?)? "}"
 object_elem : (identifier | expression) ("=" | ":")? expression
 
 heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc)/

--- a/test/helpers/terraform-config-json/variables.json
+++ b/test/helpers/terraform-config-json/variables.json
@@ -21,6 +21,11 @@
           }
         ]
       }
+    },
+    {
+      "options": {
+        "default": [{}]
+      }
     }
   ],
   "locals": [

--- a/test/helpers/terraform-config/variables.tf
+++ b/test/helpers/terraform-config/variables.tf
@@ -21,6 +21,11 @@ variable "azs" {
   }
 }
 
+variable "options" {
+  default = {
+  }
+}
+
 locals {
   route53_forwarding_rule_shares = {
     for forwarding_rule_key in keys(var.route53_resolver_forwarding_rule_shares) :


### PR DESCRIPTION
The following is valid HCL:
```
variable "foo" {
  type = map
  default = {
    # explanatory comment
  }
}
```
Update the grammar to accept objects that contain newlines but no keys