### PR TITLE
change cache to internal temp dir

### DIFF
--- a/hcl2/parser.py
+++ b/hcl2/parser.py
@@ -1,13 +1,11 @@
 """A parser for HCL2 implemented using the Lark parser"""
 from importlib import resources
-from pathlib import Path
 from typing import Dict
 
 from lark import Lark
 
 from hcl2.transformer import DictTransformer
 
-PARSER_FILE = Path(__file__).parent / ".lark_cache.bin"
 LARK_GRAMMAR = resources.read_text(__package__, "hcl2.lark")
 
 
@@ -37,11 +35,12 @@ def strip_line_comment(line: str):
 class Hcl2:
     """Wrapper class for Lark"""
 
+    lark_parser = Lark(grammar=LARK_GRAMMAR, parser="lalr", cache=True)
+
     def parse(self, text: str) -> Dict:
         """Parses a HCL file and returns a dict"""
 
-        lark_parser = Lark(grammar=LARK_GRAMMAR, parser="lalr", cache=str(PARSER_FILE))
-        tree = lark_parser.parse(text)
+        tree = Hcl2.lark_parser.parse(text)
         return DictTransformer().transform(tree)
 
 

--- a/test/unit/test_load.py
+++ b/test/unit/test_load.py
@@ -4,7 +4,6 @@ import os
 from unittest import TestCase
 
 import hcl2
-from hcl2.parser import PARSER_FILE
 
 HCL2_DIR = 'terraform-config'
 JSON_DIR = 'terraform-config-json'
@@ -18,13 +17,6 @@ class TestLoad(TestCase):
         os.chdir(os.path.join(os.path.dirname(__file__), '../helpers'))
 
     def test_load_terraform(self):
-        """Test parsing a set of hcl2 files and force recreating the parser file"""
-        # delete the parser file to force it to be recreated
-        if PARSER_FILE.exists():
-            PARSER_FILE.unlink()
-        self._load_test_files()
-
-    def test_load_terraform_from_cache(self):
         """Test parsing a set of hcl2 files from a cached parser file"""
         self._load_test_files()
 


### PR DESCRIPTION
- moved init of parser to class level, so it will be initialized only once -> much better performance
- changed cache dir to internal temp dir, no housekeeping needed