### PR TITLE
add line attribute and fix multiple new line issues

### DIFF
--- a/hcl2/__init__.py
+++ b/hcl2/__init__.py
@@ -3,3 +3,4 @@
 from .version import __version__
 
 from .api import load, loads
+from .transformer import END_LINE, START_LINE

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -1,23 +1,23 @@
-start : new_line_or_comment? body new_line_or_comment?
-body : (attribute | block )*
-attribute : (identifier) "=" expression (new_line_or_comment)?
-block : identifier (identifier | STRING_LIT)* "{" (new_line_or_comment)? body "}" new_line_or_comment
-new_line_and_or_comma: new_line_or_comment | "," | "," new_line_or_comment
-new_line_or_comment: ( /\n/ | /#.*\n/ | /\/\/.*\n/ )+
+start : _NEW_LINE_OR_COMMENT? body _NEW_LINE_OR_COMMENT?
+body : (attribute | block _NEW_LINE_OR_COMMENT+ )*
+attribute : (identifier) "=" expression _NEW_LINE_OR_COMMENT*
+block : identifier (identifier | STRING_LIT)* "{" _NEW_LINE_OR_COMMENT* body "}"
+
+_NEW_LINE_OR_COMMENT: ( /\r?\n/ | /#.*\n/ | /\/\/.*\n/ )+
 
 identifier : /[a-zA-Z_][a-zA-Z0-9_-]*/
 
-?expression : expr_term | operation | conditional
+?expression : expr_term _NEW_LINE_OR_COMMENT? | operation | conditional
 
-conditional : expression "?" new_line_or_comment? expression new_line_or_comment? ":" new_line_or_comment? expression
+conditional : expression "?" _NEW_LINE_OR_COMMENT? expression _NEW_LINE_OR_COMMENT? ":" _NEW_LINE_OR_COMMENT? expression _NEW_LINE_OR_COMMENT?
 
 ?operation : unary_op | binary_op
 !unary_op : ("-" | "!") expr_term
 binary_op : expression binary_term
 !binary_operator : "==" | "!=" | "<" | ">" | "<=" | ">=" | "-" | "*" | "/" | "%" | "&&" | "||" | "+"
-binary_term : binary_operator new_line_or_comment? expression
+binary_term : binary_operator _NEW_LINE_OR_COMMENT? expression
 
-expr_term : "(" new_line_or_comment? expression new_line_or_comment? ")"
+expr_term : "(" _NEW_LINE_OR_COMMENT? expression _NEW_LINE_OR_COMMENT? ")"
             | float_lit
             | int_lit
             | STRING_LIT
@@ -46,29 +46,29 @@ int_lit : DECIMAL+
 DECIMAL : "0".."9"
 EXP_MARK : ("e" | "E") ("+" | "-")?
 
-tuple : "[" (new_line_or_comment? expression (new_line_or_comment? "," new_line_or_comment? expression)* new_line_or_comment? ","?)? new_line_or_comment? "]"
-object : "{" new_line_or_comment? (object_elem (new_line_and_or_comma object_elem )* new_line_and_or_comma?)? "}"
+tuple : "[" (_NEW_LINE_OR_COMMENT* expression (_NEW_LINE_OR_COMMENT* "," _NEW_LINE_OR_COMMENT* expression)* ","? _NEW_LINE_OR_COMMENT*)? _NEW_LINE_OR_COMMENT? "]"
+object : "{" _NEW_LINE_OR_COMMENT* (object_elem (","? _NEW_LINE_OR_COMMENT* object_elem )* ","? _NEW_LINE_OR_COMMENT*)* "}"
 object_elem : (identifier | expression) ("=" | ":")? expression
 
 heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc)/
 heredoc_template_trim : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc_trim)/
 
-function_call : identifier "(" new_line_or_comment? arguments? new_line_or_comment? ")"
-arguments : (expression (new_line_or_comment? "," new_line_or_comment?  expression)* ("," | "...")? new_line_or_comment?)
+function_call : identifier "(" _NEW_LINE_OR_COMMENT? arguments? _NEW_LINE_OR_COMMENT? ")"
+arguments : (expression (_NEW_LINE_OR_COMMENT? "," _NEW_LINE_OR_COMMENT?  expression)* ("," | "...")? _NEW_LINE_OR_COMMENT?)
 
 index_expr_term : expr_term index
 get_attr_expr_term : expr_term get_attr
 attr_splat_expr_term : expr_term attr_splat
 full_splat_expr_term : expr_term full_splat
-index : "[" new_line_or_comment? expression new_line_or_comment? "]" | "." DECIMAL+
+index : "[" _NEW_LINE_OR_COMMENT? expression _NEW_LINE_OR_COMMENT? "]" | "." DECIMAL+
 ?get_attr : "." identifier
 ?attr_splat : ".*" get_attr*
 ?full_splat : "[" "*" "]" (get_attr | index)*
 
-!for_tuple_expr : "[" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? for_cond? new_line_or_comment? "]"
-!for_object_expr : "{" new_line_or_comment? for_intro expression "=>" new_line_or_comment? expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
-!for_intro : "for" new_line_or_comment? identifier ("," identifier new_line_or_comment?)? new_line_or_comment? "in" new_line_or_comment? expression ":" new_line_or_comment?
-!for_cond : "if" new_line_or_comment? expression
+!for_tuple_expr : "[" _NEW_LINE_OR_COMMENT? for_intro _NEW_LINE_OR_COMMENT? expression _NEW_LINE_OR_COMMENT? for_cond? _NEW_LINE_OR_COMMENT? "]"
+!for_object_expr : "{" _NEW_LINE_OR_COMMENT? for_intro expression "=>" _NEW_LINE_OR_COMMENT? expression "..."? _NEW_LINE_OR_COMMENT? for_cond? _NEW_LINE_OR_COMMENT? "}"
+!for_intro : "for" _NEW_LINE_OR_COMMENT? identifier ("," identifier _NEW_LINE_OR_COMMENT?)? _NEW_LINE_OR_COMMENT? "in" _NEW_LINE_OR_COMMENT? expression ":" _NEW_LINE_OR_COMMENT?
+!for_cond : "if" _NEW_LINE_OR_COMMENT? expression
 
 %ignore /[ \t]+/
 %ignore /\/\*(.|\n)*?(\*\/)/

--- a/hcl2/parser.py
+++ b/hcl2/parser.py
@@ -35,7 +35,7 @@ def strip_line_comment(line: str):
 class Hcl2:
     """Wrapper class for Lark"""
 
-    lark_parser = Lark(grammar=LARK_GRAMMAR, parser="lalr", cache=True)
+    lark_parser = Lark(grammar=LARK_GRAMMAR, parser="lalr", propagate_positions=True, cache=True)
 
     def parse(self, text: str) -> Dict:
         """Parses a HCL file and returns a dict"""

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -129,9 +129,6 @@ class DictTransformer(Transformer):
 
         return result
 
-    def one_line_block(self, args: List) -> Dict:
-        return self.block(args)
-
     def attribute(self, args: List) -> Dict:
         key = str(args[0])
         if key.startswith('"') and key.endswith('"'):

--- a/test/helpers/terraform-config-json/backend.json
+++ b/test/helpers/terraform-config-json/backend.json
@@ -4,7 +4,9 @@
       "aws": {
         "region": [
           "${var.region}"
-          ]
+        ],
+        "__start_line__": 2,
+        "__end_line__": 4
       }
     },
     {
@@ -14,7 +16,9 @@
         ],
         "alias": [
           "backup"
-        ]
+        ],
+        "__start_line__": 7,
+        "__end_line__": 10
       }
     }
   ],
@@ -22,7 +26,9 @@
     {
       "required_version": [
         "0.12"
-      ]
+      ],
+      "__start_line__": 15,
+      "__end_line__": 15
     },
     {
       "backend": [
@@ -34,21 +40,23 @@
         {
           "aws": [
             {
-            "source": "hashicorp/aws"
-          }
+              "source": "hashicorp/aws"
+            }
           ],
           "null": [
             {
-            "source": "hashicorp/null"
-          }
+              "source": "hashicorp/null"
+            }
           ],
           "template": [
             {
-            "source": "hashicorp/template"
-          }
-            ]
+              "source": "hashicorp/template"
+            }
+          ]
         }
-      ]
+      ],
+      "__start_line__": 17,
+      "__end_line__": 30
     }
   ]
 }

--- a/test/helpers/terraform-config-json/cloudwatch.json
+++ b/test/helpers/terraform-config-json/cloudwatch.json
@@ -8,7 +8,9 @@
           ],
           "event_pattern": [
             "    {\n      \"foo\": \"bar\"\n    }"
-          ]
+          ],
+          "__start_line__": 1,
+          "__end_line__": 8
         }
       }
     },
@@ -20,7 +22,9 @@
           ],
           "event_pattern": [
             "{\n  \"foo\": \"bar\"\n}"
-          ]
+          ],
+          "__start_line__": 10,
+          "__end_line__": 17
         }
       }
     },
@@ -32,7 +36,9 @@
           ],
           "event_pattern": [
             "${jsonencode(var.cloudwatch_pattern_deploytool)}"
-          ]
+          ],
+          "__start_line__": 19,
+          "__end_line__": 22
         }
       }
     }

--- a/test/helpers/terraform-config-json/data_sources.json
+++ b/test/helpers/terraform-config-json/data_sources.json
@@ -8,7 +8,9 @@
           ],
           "backend": [
             "s3"
-          ]
+          ],
+          "__start_line__": 1,
+          "__end_line__": 8
         }
       }
     }

--- a/test/helpers/terraform-config-json/iam.json
+++ b/test/helpers/terraform-config-json/iam.json
@@ -29,7 +29,9 @@
                 "${aws_s3_bucket.bucket.*.arn}"
               ]
             }
-          ]
+          ],
+          "__start_line__": 1,
+          "__end_line__": 19
         }
       }
     },
@@ -47,7 +49,9 @@
                 "${[for bucket_name in local.buckets_to_proxy : \"arn:aws:s3:::${bucket_name}/*\" if substr(bucket_name,0,1) == \"l\"]}"
               ]
             }
-          ]
+          ],
+          "__start_line__": 21,
+          "__end_line__": 37
         }
       }
     }

--- a/test/helpers/terraform-config-json/multiline.json
+++ b/test/helpers/terraform-config-json/multiline.json
@@ -10,7 +10,9 @@
       ],
       "transform": [
         "${{for s in local.some_strings : s => {'name': '${upper(s)}', 'tag': 'test'}}}"
-      ]
+      ],
+      "__start_line__": 1,
+      "__end_line__": 10
     }
   ]
 }

--- a/test/helpers/terraform-config-json/multiline_expression.json
+++ b/test/helpers/terraform-config-json/multiline_expression.json
@@ -1,0 +1,38 @@
+{
+  "locals": [
+    {
+      "ternary_single_line": [
+        "${var.test == \"\" ? 0 : 1}"
+      ],
+      "ternary_question_mark_break": [
+        "${var.test == \"\" ? 0 : 1}"
+      ],
+      "ternary_colon_break": [
+        "${var.test == \"\" ? 0 : 1}"
+      ],
+      "ternary_multi_line": [
+        "${var.test == \"\" ? 0 : 1}"
+      ],
+      "ternary_pre_question_mark_break": [
+        "${var.test == \"\" ? 0 : 1}"
+      ],
+      "ternary_pre_colon_break": [
+        "${var.test == \"\" ? 0 : 1}"
+      ],
+      "ternary_pre_multi_line": [
+        "${var.test == \"\" ? 0 : 1}"
+      ],
+      "binary_single_line": [
+        "${False || True}"
+      ],
+      "binary_operator_break": [
+        "${False || True}"
+      ],
+      "binary_pre_operator_break": [
+        "${False || True}"
+      ],
+      "__start_line__": 1,
+      "__end_line__": 32
+    }
+  ]
+}

--- a/test/helpers/terraform-config-json/null_provider.json
+++ b/test/helpers/terraform-config-json/null_provider.json
@@ -5,11 +5,13 @@
         {
           "null": [
             {
-            "source": "hashicorp/null"
-          }
-            ]
+              "source": "hashicorp/null"
+            }
+          ]
         }
-      ]
+      ],
+      "__start_line__": 1,
+      "__end_line__": 7
     }
   ]
 }

--- a/test/helpers/terraform-config-json/route_table.json
+++ b/test/helpers/terraform-config-json/route_table.json
@@ -14,7 +14,9 @@
           ],
           "transit_gateway_id": [
             "${data.aws_ec2_transit_gateway.tgw[0].id}"
-          ]
+          ],
+          "__start_line__": 1,
+          "__end_line__": 11
         }
       }
     },
@@ -32,7 +34,9 @@
           ],
           "transit_gateway_id": [
             "${data.aws_ec2_transit_gateway.tgw[0].id}"
-          ]
+          ],
+          "__start_line__": 13,
+          "__end_line__": 18
         }
       }
     }

--- a/test/helpers/terraform-config-json/s3.json
+++ b/test/helpers/terraform-config-json/s3.json
@@ -33,7 +33,7 @@
                   "storage_class": "GLACIER"
                 }
               ]
-              }
+            }
           ],
           "versioning": [
             {
@@ -41,7 +41,9 @@
                 true
               ]
             }
-          ]
+          ],
+          "__start_line__": 1,
+          "__end_line__": 27
         }
       }
     }
@@ -60,7 +62,9 @@
         ],
         "region": [
           "${var.region}"
-        ]
+        ],
+        "__start_line__": 29,
+        "__end_line__": 35
       }
     }
   ]

--- a/test/helpers/terraform-config-json/variables.json
+++ b/test/helpers/terraform-config-json/variables.json
@@ -1,10 +1,16 @@
 {
   "variable": [
     {
-      "region": {}
+      "region": {
+        "__start_line__": 1,
+        "__end_line__": 2
+      }
     },
     {
-      "account": {}
+      "account": {
+        "__start_line__": 4,
+        "__end_line__": 5
+      }
     },
     {
       "azs": {
@@ -19,12 +25,18 @@
             "ap-southeast-1": "ap-southeast-1a,ap-southeast-1b,ap-southeast-1c",
             "ap-southeast-2": "ap-southeast-2a,ap-southeast-2b,ap-southeast-2c"
           }
-        ]
+        ],
+        "__start_line__": 14,
+        "__end_line__": 25
       }
     },
     {
       "options": {
-        "default": [{}]
+        "default": [
+          {}
+        ],
+        "__start_line__": 27,
+        "__end_line__": 30
       }
     }
   ],
@@ -37,15 +49,19 @@
         {
           "baz": 1
         }
-      ]
-      },
+      ],
+      "__start_line__": 7,
+      "__end_line__": 12
+    },
     {
       "route53_forwarding_rule_shares": [
         "${{for forwarding_rule_key in keys(var.route53_resolver_forwarding_rule_shares) : \"${forwarding_rule_key}\" => {'aws_account_ids': '${[for account_name in var.route53_resolver_forwarding_rule_shares[forwarding_rule_key].aws_account_names : module.remote_state_subaccounts.map[account_name].outputs[\"aws_account_id\"]]}'}}}"
       ],
       "has_valid_forwarding_rules_template_inputs": [
         "${length(keys(var.forwarding_rules_template.copy_resolver_rules)) > 0 && length(var.forwarding_rules_template.replace_with_target_ips) > 0 && length(var.forwarding_rules_template.exclude_cidrs) > 0}"
-      ]
+      ],
+      "__start_line__": 32,
+      "__end_line__": 49
     }
   ]
 }

--- a/test/helpers/terraform-config/multiline_expression.tf
+++ b/test/helpers/terraform-config/multiline_expression.tf
@@ -1,0 +1,32 @@
+locals {
+  ternary_single_line = var.test == "" ? 0 : 1
+
+  ternary_question_mark_break = var.test == "" ?
+  0 : 1
+
+  ternary_colon_break = var.test == "" ? 0 :
+  1
+
+  ternary_multi_line = var.test == "" ?
+  0 :
+  1
+
+  ternary_pre_question_mark_break = var.test == ""
+  ? 0 : 1
+
+  ternary_pre_colon_break = var.test == "" ? 0
+  : 1
+
+  ternary_pre_multi_line = var.test == ""
+  ? 0
+  : 1
+
+  binary_single_line = (false || true)
+
+  binary_operator_break = (false ||
+  true)
+
+  binary_pre_operator_break = (false
+  || true)
+
+}

--- a/test/helpers/terraform-config/s3.tf
+++ b/test/helpers/terraform-config/s3.tf
@@ -8,16 +8,20 @@ resource "aws_s3_bucket" "name" {
     enabled = true
 
     expiration {
+      // much more comments
       days = 365
     }
 
     transition = {
+      # way more comments
       days          = 30
       storage_class = "GLACIER"
     }
+    # some comment
   }
 
   versioning {
+    # more comments
     enabled = true
   }
 }

--- a/test/unit/test_parse.py
+++ b/test/unit/test_parse.py
@@ -97,11 +97,14 @@ class TestParse(TestCase):
         # failure scenarios are handled in the other tests
 
     def test_parse_windows_line_separator(self):
+        """Test parsing a windows line separator"""
+
         crlf_str = 'variable "region" {\r\n}\r\n'
 
         result = hcl2.loads(crlf_str)
 
-        self.assertDictEqual(result,
+        self.assertDictEqual(
+            result,
             {
                 "variable": [
                     {

--- a/test/unit/test_parse.py
+++ b/test/unit/test_parse.py
@@ -95,3 +95,21 @@ class TestParse(TestCase):
                 self.fail(f'The parser threw an exception for the string: {test_string}. {err}')
 
         # failure scenarios are handled in the other tests
+
+    def test_parse_windows_line_separator(self):
+        crlf_str = 'variable "region" {\r\n}\r\n'
+
+        result = hcl2.loads(crlf_str)
+
+        self.assertDictEqual(result,
+            {
+                "variable": [
+                    {
+                        "region": {
+                            "__start_line__": 1,
+                            "__end_line__": 2
+                        }
+                    }
+                ]
+            }
+        )


### PR DESCRIPTION
Couple of changes

- added line attributes to different block types
- removed the extra work with `Discard` usage and instead let `Lark` internally handle it
- added support for windows line breaks `\r\n`
- fixed multiple issues with weird line breaks, examples can be found in [multiline_expression.tf](https://github.com/bridgecrewio/python-hcl2/compare/master...gruebel:add-line-attr?expand=1#diff-fd4994f55a2d852851fb24253b64209c72426cf1d0c1d686a4b8c94978c5d990)

tested it against `checkov` code base and will need to adjust couple of parts, but it can parse everything 🚀 