### PR TITLE
do not try to add line numbers for inner blocks with root block names

### DIFF
--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -112,13 +112,13 @@ class DictTransformer(Transformer):
 
         current_level[self.strip_quotes(args[-2])] = args[-1]
 
-        if args[0] in TWO_BLOCK_LABEL_TYPES:
+        if args[0] in TWO_BLOCK_LABEL_TYPES and isinstance(args[1], str) and isinstance(args[2], str):
             label_1 = self.strip_quotes(args[1])
             label_2 = self.strip_quotes(args[2])
             result[args[0]][label_1][label_2][START_LINE] = meta.line
             result[args[0]][label_1][label_2][END_LINE] = meta.end_line
 
-        if args[0] in ONE_BLOCK_LABEL_TYPES:
+        if args[0] in ONE_BLOCK_LABEL_TYPES and isinstance(args[1], str):
             label_1 = self.strip_quotes(args[1])
             result[args[0]][label_1][START_LINE] = meta.line
             result[args[0]][label_1][END_LINE] = meta.end_line

--- a/test/helpers/terraform-config-json/block_names.json
+++ b/test/helpers/terraform-config-json/block_names.json
@@ -1,0 +1,53 @@
+{
+  "resource": [
+    {
+      "aws_eks_cluster": {
+        "eks_bad": {
+          "name": [
+            "bad-eks"
+          ],
+          "role_arn": [
+            "${var.role_arn}"
+          ],
+          "vpc_config": [
+            {
+              "subnet_ids": [
+                []
+              ],
+              "endpoint_public_access": [
+                true
+              ]
+            }
+          ],
+          "encryption_config": [
+            {
+              "provider": [
+                {
+                  "key_arn": [
+                    "${var.key_arn}"
+                  ]
+                }
+              ],
+              "resources": [
+                []
+              ]
+            }
+          ],
+          "resource": [
+            {
+              "data": [
+                {
+                  "some": [
+                    "thing"
+                  ]
+                }
+              ]
+            }
+          ],
+          "__start_line__": 1,
+          "__end_line__": 23
+        }
+      }
+    }
+  ]
+}

--- a/test/helpers/terraform-config/block_names.tf
+++ b/test/helpers/terraform-config/block_names.tf
@@ -1,0 +1,23 @@
+resource aws_eks_cluster "eks_bad" {
+  name = "bad-eks"
+  role_arn = var.role_arn
+  vpc_config {
+    subnet_ids = []
+    endpoint_public_access = true
+  }
+
+
+  encryption_config {
+    provider {
+      key_arn = var.key_arn
+    }
+    resources = []
+  }
+
+  #  doesn't exist, just for testing
+  resource {
+    data {
+      some = "thing"
+    }
+  }
+}


### PR DESCRIPTION
fixed an issue, when an inner block has the same name as a Terraform block