### PR TITLE
Support multiline interpolation

### DIFF
--- a/hcl2/api.py
+++ b/hcl2/api.py
@@ -1,16 +1,18 @@
 """The API that will be exposed to users of this package"""
+from __future__ import annotations
+
 import re
-from typing import TextIO
+from typing import TextIO, Any
 
 from hcl2.parser import hcl2, strip_line_comment
 
 
-def load(file: TextIO) -> dict:
+def load(file: TextIO) -> dict[str, list[dict[str, Any]]]:
     """Load a HCL2 file"""
     return loads(file.read())
 
 
-def loads(text: str) -> dict:
+def loads(text: str) -> dict[str, list[dict[str, Any]]]:
     """Load HCL2 from a string"""
     # append new line as a workaround for https://github.com/lark-parser/lark/issues/237
     # Lark doesn't support a EOF token so our grammar can't look for "new line or end of file"
@@ -30,9 +32,9 @@ def loads(text: str) -> dict:
     # ... /* a = 123     <- this will not
     in_multi_line_comment = False
     found_multi_line_comment_start = False
+    found_multi_line_interpolation_start = False
 
     for line in text.split('\n'):
-        token = None
         comment = None
         if not multi_line_string_denominator and \
                 not in_multi_line_comment and '/*' in line:
@@ -57,6 +59,15 @@ def loads(text: str) -> dict:
             # (but we don't want to do this for every line if it's not necessary)
             stripped = strip_line_comment(line)[0] if not comment else line  # maybe we already stripped it
             if stripped.replace('\\"', '').count('"') % 2 != 0:
+                if "${" in stripped and stripped.index('"') < stripped.index("${"):
+                    # this seems to be a multiline interpolation string
+                    found_multi_line_interpolation_start = True
+                    continue
+                if found_multi_line_interpolation_start and "}" in stripped and stripped.index("}") < stripped.index('"'):
+                    # found also the closing end
+                    found_multi_line_interpolation_start = False
+                    continue
+
                 # the stripped off comment is still an unclosed string, so now we have a real error
                 raise ValueError(f"Line has unclosed quote marks: {line}")
 

--- a/hcl2/api.py
+++ b/hcl2/api.py
@@ -59,11 +59,19 @@ def loads(text: str) -> dict[str, list[dict[str, Any]]]:
             # (but we don't want to do this for every line if it's not necessary)
             stripped = strip_line_comment(line)[0] if not comment else line  # maybe we already stripped it
             if stripped.replace('\\"', '').count('"') % 2 != 0:
-                if "${" in stripped and stripped.index('"') < stripped.index("${"):
+                if (
+                    "${" in stripped
+                    and "}" not in stripped
+                    and stripped.index('"') < stripped.index("${")
+                ):
                     # this seems to be a multiline interpolation string
                     found_multi_line_interpolation_start = True
                     continue
-                if found_multi_line_interpolation_start and "}" in stripped and stripped.index("}") < stripped.index('"'):
+                if (
+                    found_multi_line_interpolation_start
+                    and "}" in stripped
+                    and stripped.index("}") < stripped.index('"')
+                ):
                     # found also the closing end
                     found_multi_line_interpolation_start = False
                     continue

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -53,7 +53,7 @@ object_elem : (identifier | expression) ("=" | ":")? expression
 heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc)/
 heredoc_template_trim : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc_trim)/
 
-function_call : identifier "(" _NEW_LINE_OR_COMMENT? arguments? _NEW_LINE_OR_COMMENT? ")"
+function_call : identifier "(" _NEW_LINE_OR_COMMENT* arguments? _NEW_LINE_OR_COMMENT? ")"
 arguments : (expression (_NEW_LINE_OR_COMMENT? "," _NEW_LINE_OR_COMMENT?  expression)* ("," | "...")? _NEW_LINE_OR_COMMENT?)
 
 index_expr_term : expr_term index

--- a/hcl2/parser.py
+++ b/hcl2/parser.py
@@ -1,6 +1,8 @@
 """A parser for HCL2 implemented using the Lark parser"""
+from __future__ import annotations
+
 from importlib import resources
-from typing import Dict
+from typing import Any
 
 from lark import Lark
 
@@ -9,7 +11,7 @@ from hcl2.transformer import DictTransformer
 LARK_GRAMMAR = resources.read_text(__package__, "hcl2.lark")
 
 
-def strip_line_comment(line: str):
+def strip_line_comment(line: str) -> tuple[str, str, str] | tuple[str, None, None]:
     """
     Finds the start of a comment in the line, if any, and returns the line
     up to the comment, the token that started the comment (#, //, or /*),
@@ -28,7 +30,7 @@ def strip_line_comment(line: str):
                 # we are not in a string, so this marks the start of a comment
                 return line[0:index], token, line[index + len(token):]
         index += 1
-# abcd#
+
     return line, None, None
 
 
@@ -37,7 +39,7 @@ class Hcl2:
 
     lark_parser = Lark(grammar=LARK_GRAMMAR, parser="lalr", propagate_positions=True, cache=True)
 
-    def parse(self, text: str) -> Dict:
+    def parse(self, text: str) -> dict[str, list[dict[str, Any]]]:
         """Parses a HCL file and returns a dict"""
 
         tree = Hcl2.lark_parser.parse(text)

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import List, Dict, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
-from lark import Transformer
+from lark import Transformer, Token
 from lark.visitors import v_args
 
 if TYPE_CHECKING:
@@ -23,14 +23,14 @@ TWO_BLOCK_LABEL_TYPES = {"data", "resource"}
 
 
 # pylint: disable=missing-docstring,unused-argument
-class DictTransformer(Transformer):
-    def float_lit(self, args: List) -> float:
+class DictTransformer(Transformer[Token, "dict[str, list[dict[str, Any]]]"]):
+    def float_lit(self, args: list) -> float:
         return float("".join([str(arg) for arg in args]))
 
-    def int_lit(self, args: List) -> int:
+    def int_lit(self, args: list) -> int:
         return int("".join([str(arg) for arg in args]))
 
-    def expr_term(self, args: List) -> Any:
+    def expr_term(self, args: list) -> Any:
         args = self.strip_new_line_tokens(args)
 
         #
@@ -47,27 +47,27 @@ class DictTransformer(Transformer):
         # otherwise return the value itself
         return args[0]
 
-    def index_expr_term(self, args: List) -> str:
+    def index_expr_term(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         return f"{str(args[0])}{str(args[1])}"
 
-    def index(self, args: List) -> str:
+    def index(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         return f"[{str(args[0])}]"
 
-    def get_attr_expr_term(self, args: List) -> str:
+    def get_attr_expr_term(self, args: list) -> str:
         return f"{str(args[0])}.{str(args[1])}"
 
-    def attr_splat_expr_term(self, args: List) -> str:
+    def attr_splat_expr_term(self, args: list) -> str:
         return f"{args[0]}.*.{args[1]}"
 
-    def full_splat_expr_term(self, args: List) -> str:
+    def full_splat_expr_term(self, args: list) -> str:
         return f"{args[0]}[*].{args[1]}"
 
-    def tuple(self, args: List) -> List:
+    def tuple(self, args: list) -> list:
         return [self.to_string_dollar(arg) for arg in self.strip_new_line_tokens(args)]
 
-    def object_elem(self, args: List) -> Dict:
+    def object_elem(self, args: list) -> dict[str, Any]:
         # This returns a dict with a single key/value pair to make it easier to merge these
         # into a bigger dict that is returned by the "object" function
         key = self.strip_quotes(args[0])
@@ -77,25 +77,25 @@ class DictTransformer(Transformer):
             key: value,
         }
 
-    def object(self, args: List) -> Dict:
+    def object(self, args: list) -> dict:
         args = self.strip_new_line_tokens(args)
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         for arg in args:
             result.update(arg)
         return result
 
-    def function_call(self, args: List) -> str:
+    def function_call(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         args_str = ""
         if len(args) > 1:
             args_str = ",".join([str(arg) for arg in args[1]])
         return f"{str(args[0])}({args_str})"
 
-    def arguments(self, args: List) -> List:
+    def arguments(self, args: list) -> list:
         return args
 
     @v_args(meta=True)
-    def block(self, meta: Meta, args: List) -> Dict:
+    def block(self, meta: Meta, args: list) -> dict[str, Any]:
         args = self.strip_new_line_tokens(args)
 
         # if the last token is a string instead of an object then the block is empty
@@ -104,7 +104,7 @@ class DictTransformer(Transformer):
         if isinstance(args[-1], str):
             args.append({})
 
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         current_level = result
         for arg in args[0:-2]:
             current_level[self.strip_quotes(arg)] = {}
@@ -129,7 +129,7 @@ class DictTransformer(Transformer):
 
         return result
 
-    def attribute(self, args: List) -> Dict:
+    def attribute(self, args: list) -> dict[str, Any]:
         key = str(args[0])
         if key.startswith('"') and key.endswith('"'):
             key = key[1:-1]
@@ -139,28 +139,28 @@ class DictTransformer(Transformer):
             key: value,
         }
 
-    def conditional(self, args: List) -> str:
+    def conditional(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         return f"{args[0]} ? {args[1]} : {args[2]}"
 
-    def binary_op(self, args: List) -> str:
+    def binary_op(self, args: list) -> str:
         return " ".join([str(arg) for arg in args])
 
-    def unary_op(self, args: List) -> str:
+    def unary_op(self, args: list) -> str:
         return "".join([str(arg) for arg in args])
 
-    def binary_term(self, args: List) -> str:
+    def binary_term(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         return " ".join([str(arg) for arg in args])
 
-    def body(self, args: List) -> Dict[str, List]:
+    def body(self, args: list) -> dict[str, list]:
         # A body can have multiple attributes with the same name
         # For example multiple Statement attributes in a IAM resource body
         # So This returns a dict of attribute names to lists
         # The attribute values will always be lists even if they aren't repeated
         # and only contain a single entry
         args = self.strip_new_line_tokens(args)
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         for arg in args:
             for key, value in arg.items():
                 key = str(key)
@@ -177,20 +177,20 @@ class DictTransformer(Transformer):
 
         return result
 
-    def start(self, args: List) -> Dict:
+    def start(self, args: list) -> dict[str, list[dict[str, Any]]]:
         args = self.strip_new_line_tokens(args)
         return args[0]
 
-    def binary_operator(self, args: List) -> str:
+    def binary_operator(self, args: list) -> str:
         return str(args[0])
 
-    def heredoc_template(self, args: List) -> str:
+    def heredoc_template(self, args: list) -> str:
         match = HEREDOC_PATTERN.match(str(args[0]))
         if not match:
             raise RuntimeError(f"Invalid Heredoc token: {args[0]}")
         return f'"{match.group(2)}"'
 
-    def heredoc_template_trim(self, args: List) -> str:
+    def heredoc_template_trim(self, args: list) -> str:
         # See https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md#template-expressions
         # This is a special version of heredocs that are declared with "<<-"
         # This will calculate the minimum number of leading spaces in each line of a heredoc
@@ -213,25 +213,25 @@ class DictTransformer(Transformer):
 
         return '"{}"'.format("\n".join(lines))
 
-    def for_tuple_expr(self, args: List) -> str:
+    def for_tuple_expr(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         for_expr = " ".join([str(arg) for arg in args[1:-1]])
         return f"[{for_expr}]"
 
-    def for_intro(self, args: List) -> str:
+    def for_intro(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         return " ".join([str(arg) for arg in args])
 
-    def for_cond(self, args: List) -> str:
+    def for_cond(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         return " ".join([str(arg) for arg in args])
 
-    def for_object_expr(self, args: List) -> str:
+    def for_object_expr(self, args: list) -> str:
         args = self.strip_new_line_tokens(args)
         for_expr = " ".join([str(arg) for arg in args[1:-1]])
         return f"{{{for_expr}}}"
 
-    def strip_new_line_tokens(self, args: List) -> List:
+    def strip_new_line_tokens(self, args: list[Any]) -> list[Any]:
         """
         Remove new line and Discard tokens.
         The parser will sometimes include these in the tree so we need to strip them out here

--- a/test/helpers/terraform-config-json/multiline_expression.json
+++ b/test/helpers/terraform-config-json/multiline_expression.json
@@ -34,5 +34,29 @@
       "__start_line__": 1,
       "__end_line__": 32
     }
+  ],
+  "variable": [
+    {
+      "some_var": {
+        "description": [
+          "description"
+        ],
+        "type": [
+          "${string}"
+        ],
+        "validation": [
+          {
+            "condition": [
+              "${alltrue(['${length(regexall(\"^st\",var.name)) == 0}'])}"
+            ],
+            "error_message": [
+              "error"
+            ]
+          }
+        ],
+        "__start_line__": 34,
+        "__end_line__": 61
+      }
+    }
   ]
 }

--- a/test/helpers/terraform-config-json/multiline_expression.json
+++ b/test/helpers/terraform-config-json/multiline_expression.json
@@ -47,7 +47,7 @@
         "validation": [
           {
             "condition": [
-              "${alltrue(['${length(regexall(\"^st\",var.name)) == 0}'])}"
+              "${alltrue(['${length(regexall(\"^st\",var.some_var)) == 0}'])}"
             ],
             "error_message": [
               "error"

--- a/test/helpers/terraform-config-json/multiline_interpolation.json
+++ b/test/helpers/terraform-config-json/multiline_interpolation.json
@@ -1,0 +1,14 @@
+{
+  "locals": [
+    {
+      "multiline": [
+        "${\n    max(\n      ceil(\n        log((local.instance_memory * 1024) / 21474836480, 2) * 600\n      ),\n      200\n    )\n  }"
+      ],
+      "multiline_2": [
+        "${max(\n      ceil(\n        log((local.instance_memory * 1024) / 21474836480, 2) * 600\n      ),\n      200\n  )}"
+      ],
+      "__start_line__": 1,
+      "__end_line__": 17
+    }
+  ]
+}

--- a/test/helpers/terraform-config/multiline_expression.tf
+++ b/test/helpers/terraform-config/multiline_expression.tf
@@ -30,3 +30,32 @@ locals {
   || true)
 
 }
+
+variable "some_var" {
+  description = "description"
+  type        = string
+  # comment 1
+  # comment 2
+  validation {
+    # comment 3
+    # comment 4
+    condition = alltrue(
+      # comment 5
+      # comment 6
+      [
+        # comment 7
+        # comment 8
+        length(regexall("^st", var.some_var)) == 0,
+        # comment 9
+        # comment 10
+      ]
+      # comment 11
+      # comment 12
+    )
+    # comment 13
+    # comment 14
+    error_message = "error"
+  }
+  # comment 15
+  # comment 16
+}

--- a/test/helpers/terraform-config/multiline_interpolation.tf
+++ b/test/helpers/terraform-config/multiline_interpolation.tf
@@ -1,0 +1,17 @@
+locals {
+  multiline = "${
+    max(
+      ceil(
+        log((local.instance_memory * 1024) / 21474836480, 2) * 600
+      ),
+      200
+    )
+  }"
+
+  multiline_2 = "${max(
+      ceil(
+        log((local.instance_memory * 1024) / 21474836480, 2) * 600
+      ),
+      200
+  )}"
+}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ basepython=python3.7
 commands =
     pip install --upgrade -r requirements.pip -r test-requirements.pip -e .
     pylint --rcfile=pylintrc --output-format=colorized hcl2 test bin setup.py
-    pycodestyle hcl2 test bin setup.py
+    pycodestyle --ignore W503 hcl2 test bin setup.py
     mypy hcl2
     # run markdown lint. If this fails then run `remark . -o` to reformat all markdown files
     npm install


### PR DESCRIPTION
- fixed an issue with comments inside a function call https://github.com/bridgecrewio/checkov/issues/2771
- added support for multiline interpolation strings as can be seen here [multiline_interpolation.tf](https://github.com/bridgecrewio/python-hcl2/compare/master...bridgecrewio:support-multiline-interpolation?expand=1#diff-011e3ca0f8fb6eadebc955bc2ac94a6e933482f549ee995134309bd61b3b9a75)
- adjusted some type hints, nothing fancy