### PR TITLE
adds support for comments interleaved in func args

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -54,7 +54,7 @@ heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=
 heredoc_template_trim : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc_trim)/
 
 function_call : identifier "(" _NEW_LINE_OR_COMMENT* arguments? _NEW_LINE_OR_COMMENT? ")"
-arguments : (expression (_NEW_LINE_OR_COMMENT? "," _NEW_LINE_OR_COMMENT?  expression)* ("," | "...")? _NEW_LINE_OR_COMMENT?)
+arguments : (expression (_NEW_LINE_OR_COMMENT* "," _NEW_LINE_OR_COMMENT*  expression)* ("," | "...")? _NEW_LINE_OR_COMMENT*)
 
 index_expr_term : expr_term index
 get_attr_expr_term : expr_term get_attr

--- a/test/helpers/terraform-config-json/multiline_expression.json
+++ b/test/helpers/terraform-config-json/multiline_expression.json
@@ -57,6 +57,21 @@
         "__start_line__": 34,
         "__end_line__": 61
       }
+    },
+    {
+      "some_var2": {
+        "description": [
+          "description"
+        ],
+        "type": [
+          "${string}"
+        ],
+        "default": [
+          "${cidrsubnets(\"10.0.0.0/24\",2,2)}"
+        ],
+        "__start_line__": 63,
+        "__end_line__": 79
+      }
     }
   ]
 }

--- a/test/helpers/terraform-config/multiline_expression.tf
+++ b/test/helpers/terraform-config/multiline_expression.tf
@@ -59,3 +59,21 @@ variable "some_var" {
   # comment 15
   # comment 16
 }
+
+variable "some_var2" {
+  description = "description"
+  type        = string
+  default     = cidrsubnets(
+    # comment 1
+    # comment 2
+    "10.0.0.0/24",
+    # comment 3
+    # comment 4
+    2,
+    # comment 5
+    # comment 6
+    2
+    # comment 7
+    # comment 8
+  )
+}


### PR DESCRIPTION
Also includes test case to catch this.

For reference,
comments 3,4,5, and 6 cause the issue now explicity handled.

Using tox, I have tested this in python 3.8.10
I can test on all tox specified versions if required, but this will take some time, as my Windows Python install is currently "indescribably confusing and horrendously convoluted".