### PR TITLE
support multiple comment blocks at file start

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -1,4 +1,4 @@
-start : _NEW_LINE_OR_COMMENT? body _NEW_LINE_OR_COMMENT?
+start : _NEW_LINE_OR_COMMENT* body _NEW_LINE_OR_COMMENT?
 body : (attribute | block _NEW_LINE_OR_COMMENT+ )*
 attribute : (identifier) "=" expression _NEW_LINE_OR_COMMENT*
 block : identifier (identifier | STRING_LIT)* "{" _NEW_LINE_OR_COMMENT* body "}"
@@ -71,4 +71,4 @@ full_splat : "[*]" (get_attr | index)*
 !for_cond : "if" _NEW_LINE_OR_COMMENT? expression
 
 %ignore /[ \t]+/
-%ignore /\/\*(.|\n)*?(\*\/)/
+%ignore /\/\*(.|\n)*?\*\//

--- a/test/helpers/terraform-config-json/multiline.json
+++ b/test/helpers/terraform-config-json/multiline.json
@@ -11,8 +11,8 @@
       "transform": [
         "${{for s in local.some_strings : s => {'name': '${upper(s)}', 'tag': 'test'}}}"
       ],
-      "__start_line__": 1,
-      "__end_line__": 10
+      "__start_line__": 24,
+      "__end_line__": 33
     }
   ]
 }

--- a/test/helpers/terraform-config/multiline.tf
+++ b/test/helpers/terraform-config/multiline.tf
@@ -1,3 +1,26 @@
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */
 locals {
   some_strings = ["foo", "bar", "baz"]
 
@@ -8,3 +31,26 @@ locals {
     }
   }
 }
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */
+
+/*
+ * something
+ */


### PR DESCRIPTION
Relates to bridgecrewio/checkov#3023

Fixed an issue, when multiple comment blocks are at the start of a file.