### PR TITLE
Use regex package for evaluating regex expressions

### DIFF
--- a/hcl2/parser.py
+++ b/hcl2/parser.py
@@ -42,7 +42,7 @@ def strip_line_comment(line: str) -> tuple[str, str, str] | tuple[str, None, Non
 class Hcl2:
     """Wrapper class for Lark"""
 
-    lark_parser = Lark(grammar=LARK_GRAMMAR, parser="lalr", propagate_positions=True, cache=True)
+    lark_parser = Lark(grammar=LARK_GRAMMAR, parser="lalr", propagate_positions=True, cache=True, regex=True)
 
     def parse(self, text: str) -> dict[str, list[dict[str, Any]]]:
         """Parses a HCL file and returns a dict"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
 lark>=1.0.0
 importlib-resources>=2.0.0,<7.0.0; python_version < '3.9'
+regex==2024.9.11

--- a/test/helpers/terraform-config/bad_regex.tf
+++ b/test/helpers/terraform-config/bad_regex.tf
@@ -1,0 +1,9 @@
+resource "aws_glue_connection" "example" {
+  name = "example-connection"
+  connection_properties = {
+             startswith(each.value.connection_properties[x], "$${abcded:"
+
+
+variable "connection_properties" {
+
+}

--- a/test/unit/test_load.py
+++ b/test/unit/test_load.py
@@ -40,7 +40,7 @@ class TestLoad(TestCase):
                                 hcl2.load(hcl2_file)
                                 self.fail("Should throw parsing error for file")
                             except Exception as err:
-                                if not str(err).startswith('Line has unclosed quote marks'):
+                                if not str(err).startswith('Line has unclosed quote marks') and not str(err).startswith('No terminal matches'):
                                     self.fail(f'Got an unexpected error, {err}')
                     else:
                         with open(file_path, 'r', encoding='utf8') as hcl2_file, \


### PR DESCRIPTION
Instead of using lark's regex implementation, use the python regex library.
This fixes an infinite regex match that occurred in the test file.