### PR TITLE
Added support for provider functions

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -27,6 +27,7 @@ expr_term : "(" _NEW_LINE_OR_COMMENT* expression _NEW_LINE_OR_COMMENT? ")"
             | index_expr_term
             | get_attr_expr_term
             | identifier
+            | provider_function_call
             | heredoc_template
             | heredoc_template_trim
             | attr_splat_expr_term
@@ -57,6 +58,8 @@ heredoc_template_trim : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+
 function_call : identifier "(" _NEW_LINE_OR_COMMENT* arguments? _NEW_LINE_OR_COMMENT? ")"
 arguments : (expression (_NEW_LINE_OR_COMMENT* "," _NEW_LINE_OR_COMMENT*  expression)* ("," | "...")? _NEW_LINE_OR_COMMENT*)
 
+colons: "::"
+provider_function_call: identifier colons identifier colons  identifier  "(" _NEW_LINE_OR_COMMENT? arguments? _NEW_LINE_OR_COMMENT? ")"
 index_expr_term : expr_term index
 get_attr_expr_term : expr_term get_attr
 attr_splat_expr_term : expr_term attr_splat

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -6,7 +6,7 @@ import sys
 from typing import Any, TYPE_CHECKING
 
 from lark import Transformer, Token
-from lark.visitors import v_args
+from lark.visitors import v_args, Discard
 
 if TYPE_CHECKING:
     from lark.tree import Meta
@@ -106,6 +106,14 @@ class DictTransformer(Transformer[Token, "dict[str, list[dict[str, Any]]]"]):
 
     def arguments(self, args: list) -> list:
         return args
+
+    def provider_function_call(self, args: list) -> str:
+        args = self.strip_new_line_tokens(args)
+        args_str = ""
+        if len(args) > 5:
+            args_str = ", ".join([str(arg) for arg in args[5] if arg is not Discard])
+        provider_func = "::".join([args[0], args[2], args[4]])
+        return f"{provider_func}({args_str})"
 
     @v_args(meta=True)
     def block(self, meta: Meta, args: list) -> dict[str, Any]:

--- a/test/helpers/terraform-config-json/provider_function.json
+++ b/test/helpers/terraform-config-json/provider_function.json
@@ -1,0 +1,10 @@
+{
+  "locals": [
+    {
+      "name2": ["${provider::test2::test(\"a\")}"],
+      "name3": ["${test(\"a\")}"],
+      "__end_line__": 4, 
+      "__start_line__": 1
+    }
+  ]
+}

--- a/test/helpers/terraform-config/provider_function.tf
+++ b/test/helpers/terraform-config/provider_function.tf
@@ -1,0 +1,4 @@
+locals {
+  name2 = provider::test2::test("a")
+  name3 = test("a")
+}


### PR DESCRIPTION
This PR is a based on the [PR](https://github.com/amplify-education/python-hcl2/pull/162) from the main repository `amlipy/python-hcl2` to add support for provider functions in terraform